### PR TITLE
changes to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,12 @@ read generate
 if [ "$generate" == "y" ]
 then
 
-  if [[ ! -d "$HOME/.config" ]]
+  if [[ ! -d "${XDG_CONFIG_HOME:-$HOME/.config}" ]]
   then
-    mkdir "$HOME/.config"
+    mkdir "${XDG_CONFIG_HOME:-$HOME/.config}"
   fi
 
-  CONFPATH=$HOME/.config/canvas-cli/
+  CONFPATH=${XDG_CONFIG_HOME:-$HOME/.config}/canvas-tui/
 
   if [[ ! -d $CONFPATH ]]
   then

--- a/install.sh
+++ b/install.sh
@@ -1,40 +1,40 @@
-#!/bin/bash
+#!/bin/sh
 
 # FILEPATH=$(readlink -f "canvas-cli")
 
-# chmod +x canvas-t
+# chmod +x canvas-tui
 
 # ln -s $FILEPATH $HOME/.local/bin
 
 echo ""
-echo "Would you like to generate config.yaml at ~/.config/canvas-tui? This will over write any config already present there. (y/n)"
-read generate
-if [ "$generate" == "y" ]
+echo "Would you like to generate config.yaml at ~/.config/canvas-tui? This will over write any config already present there. [y/N]"
+read -r generate
+if [ "$generate" = "y" ]
 then
 
-  if [[ ! -d "${XDG_CONFIG_HOME:-$HOME/.config}" ]]
+  if [ ! -d "${XDG_CONFIG_HOME:-$HOME/.config}" ]
   then
     mkdir "${XDG_CONFIG_HOME:-$HOME/.config}"
   fi
 
   CONFPATH=${XDG_CONFIG_HOME:-$HOME/.config}/canvas-tui/
 
-  if [[ ! -d $CONFPATH ]]
+  if [ ! -d "$CONFPATH" ]
   then
-    mkdir $CONFPATH
+    mkdir "$CONFPATH"
   fi
 
   echo "What is your canvas token? Leave this blank if you don't know and will edit the config later."
-  read TOKEN
+  read -r TOKEN
 
   echo "What is your canvas domain? Example: wwu's domain is https://wwu.instructure.com/"
-  read DOMAIN
+  read -r DOMAIN
 
-  echo "canvasdomain: \"$DOMAIN\"" >> $CONFPATH/config.yaml
-  echo "canvastoken: \"$TOKEN\"" >> $CONFPATH/config.yaml
+  echo "canvasdomain: \"$DOMAIN\"" >> "$CONFPATH/config.yaml"
+  echo "canvastoken: \"$TOKEN\"" >> "$CONFPATH/config.yaml"
 
 else
   echo No config generated.
 fi
 
-  echo Make sure $HOME/.local/bin is in your PATH.
+echo "Make sure $HOME/.local/bin is in your PATH."


### PR DESCRIPTION
The config was being written to `~/.config/canvas-cli`, while the program looks in `~/.config/canvas-tui`. Changed the script to use the latter.

Switched to using the `$XDG_CONFIG_HOME` environment variable if it is set, to respect user preferences. Otherwise, fall back to the default `$HOME/.config`.

Made some changes to the shell syntax. I use [*shellcheck*](https://www.shellcheck.net/) to check for errors.
- `-r` for *read* to interpret backslashes literally.
- Double quote expressions with variables to prevent whitespace mangling.

POSIX shell (`/bin/sh`) compatibility:
- No need for non-compliant double `[[ square brackets ]]` for testing conditions.
- No need for non-compliant double `equals == sign` for comparison.